### PR TITLE
Pass "audience"' value to the Kinde client options

### DIFF
--- a/src/handle-auth.js
+++ b/src/handle-auth.js
@@ -17,6 +17,7 @@ export const kindeClient = createKindeServerClient(
       config.clientId || "Set your client ID in your environment variables.",
     clientSecret: config.clientSecret,
     redirectURL: config.siteUrl + "/kinde-auth/callback",
+    audience: config.audience,
     logoutRedirectURL:
       config.postLogoutRedirectUrl ||
       "Set your logout redirect URL in your environment variables.",


### PR DESCRIPTION
# Explain your changes

Makes sure the "audience" config field is passed to the Kinde client in the Typescript SDK. It was defined in config but was not passed along.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
