### PR TITLE
Refresh tokens only when necessary

### DIFF
--- a/src/get-kinde-session.js
+++ b/src/get-kinde-session.js
@@ -228,7 +228,7 @@ export const getKindeSession = async (request) => {
 
   const refreshTokens = async () => {
     try {
-      await kindeClient.refreshTokens(sessionManager);
+      await kindeClient.getToken(sessionManager);
       const headers = generateCookieHeader(request, cookies);
       return headers;
     } catch (error) {


### PR DESCRIPTION
# Explain your changes

Fixes #21

Quick summary: 
In Remix, `getKindeSession` is called on every application request. This function refreshes tokens on every call, even if the token is perfectly valid. Also adds unnecessary latency to the entire app.

Fix: 
Use `kindeClient.getToken` in `refreshTokens` function, which makes sure that the token is valid and only in case of an expired one, it tries to refresh it. 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
