### PR TITLE
fix: changed kinde session test to handle the updated refresh logic

### DIFF
--- a/tests/get-kinde-session.test.ts
+++ b/tests/get-kinde-session.test.ts
@@ -389,7 +389,7 @@ describe("getKindeSession", () => {
     const session = await getKindeSession(requestEvent);
     kindeClient.refreshTokens = vi.fn().mockResolvedValueOnce({});
     const headers = await session.refreshTokens();
-    expect(kindeClient.refreshTokens).toHaveBeenCalledWith(expect.anything());
+    expect(kindeClient.getToken).toHaveBeenCalledWith(expect.anything());
     expect(headers).toStrictEqual(new Headers());
   });
 


### PR DESCRIPTION
# Explain your changes

This changed fixes the refresh test to correctly check against the getToken rather than against the previous refresh token call.
# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
